### PR TITLE
Collapse long lists of item under a bib item

### DIFF
--- a/src/app/components/ItemPage/ItemHoldings.jsx
+++ b/src/app/components/ItemPage/ItemHoldings.jsx
@@ -1,6 +1,15 @@
 import React from 'react';
+import { Link } from 'react-router';
 
 class ItemHoldings extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state ={
+      expanded: false
+    };
+  }
+
   getHeading(headings) {
     return (
       <thead>
@@ -11,12 +20,22 @@ class ItemHoldings extends React.Component {
     );
   }
 
+  showMoreItems(e){
+    e.preventDefault();
+    this.setState({ expanded: true });
+  }
+
   getRow(holdings) {
+    const holdingCount = holdings.length;
+    const maxDisplay = 7;
+    const moreCount = holdingCount - maxDisplay;
+    const collapsed = !this.state.expanded;
+
     return (
       <tbody>
         {
           holdings.map((h, i) => (
-            <tr className={h.className} key={i}>
+            <tr className={`${h.className} ${i>=maxDisplay && collapsed ? 'collapsed' : ''}`} key={i}>
               <td dangerouslySetInnerHTML={this.createMarkup(h.available)}></td>
               <td dangerouslySetInnerHTML={this.createMarkup(h.location)}></td>
               <td dangerouslySetInnerHTML={this.createMarkup(h.callNumber)}></td>
@@ -24,13 +43,22 @@ class ItemHoldings extends React.Component {
             </tr>
           ))
         }
-        {/*
-        <tr className="more">
-          <td colSpan="4">
-            <a href="#see-more" className="more-link">See 2 more copies</a>
-          </td>
-        </tr>
-        */}
+        {
+          moreCount > 0 && collapsed ?
+            (
+              <tr className="more">
+                <td colSpan="4">
+                  <Link
+                    onClick={(e) => this.showMoreItems(e)}
+                    href="#see-more"
+                    className="more-link">
+                    See {moreCount} more {moreCount > 1 ? 'copies' : 'copy'}
+                  </Link>
+                </td>
+              </tr>
+            )
+            : null
+        }
       </tbody>
     );
   }
@@ -44,8 +72,16 @@ class ItemHoldings extends React.Component {
   render() {
     const headings = ['Status', 'Location', 'Call Number', ''];
 
+    const holdings = this.props.holdings;
+    // available items first
+    holdings.sort((a, b) => {
+      const aAvailability = a.availability === 'available' ? -1 : 1;
+      const bAvailability = b.availability === 'available' ? -1 : 1;
+      return aAvailability - bAvailability;
+    });
+
     const heading = this.getHeading(headings);
-    const body = this.getRow(this.props.holdings);
+    const body = this.getRow(holdings);
 
     return (
       <div className="item-holdings">

--- a/src/app/components/ItemPage/ItemPage.jsx
+++ b/src/app/components/ItemPage/ItemPage.jsx
@@ -13,10 +13,10 @@ class ItemPageRegular extends React.Component {
     // const ebscoLink = record.PLink;
     // const bibRecord = record.RecordInfo.BibRecord;
     const title = record.title[0];
-    const authors = record.contributor && record.contributor.length ? 
+    const authors = record.contributor && record.contributor.length ?
       record.contributor.map((author, i) => (<a href="#" key={i}>{author}; </a>))
       : null;
-    const authorsString = record.contributor && record.contributor.length ? 
+    const authorsString = record.contributor && record.contributor.length ?
       record.contributor.map((author, i) => (`<a href="#" key={i}>${author}; </a>`))
       : null;
     const language = record.language[0].prefLabel;
@@ -28,9 +28,11 @@ class ItemPageRegular extends React.Component {
     // const dates = bibRecord.BibRelationships.IsPartOfRelationships[0].BibEntity.Dates[0];
     const holdings = record.items.map((item, i) => {
       const available = item.availability[0].substring(7);
+      const availabilityClassname = available.replace(/\W/g, '').toLowerCase();
       return {
+        availability: availabilityClassname,
         className: '',
-        available: `<span class="status available">${available}</span> `,
+        available: `<span class="status ${availabilityClassname}">${available}</span> `,
         location: `<a href="#"> ${item.location.length ? item.location[0][0].prefLabel : null}</a>`,
         callNumber: item.idCallNum ? item.idCallNum[0] : '',
         hold: available === 'AVAILABLE' ? (<Link to={`/hold/${item['@id'].substring(4)}`} className="button">Place a hold</Link>) : null,

--- a/src/app/components/Results/ResultsList.jsx
+++ b/src/app/components/Results/ResultsList.jsx
@@ -39,6 +39,7 @@ class ResultsList extends React.Component {
   showMoreItems(e, id){
     e.preventDefault();
 
+    // This is a makeshift way of doing it; we should probably have the sub-items as another component that tracks its own expanded/collapsed state
     const expandedItems = this.state.expandedItems;
     expandedItems.push(id);
     this.setState({ expandedItems: expandedItems });

--- a/src/app/components/Results/ResultsList.jsx
+++ b/src/app/components/Results/ResultsList.jsx
@@ -8,6 +8,10 @@ class ResultsList extends React.Component {
   constructor(props) {
     super(props);
 
+    this.state ={
+      expandedItems: []
+    };
+
     this.routeHandler = this.routeHandler.bind(this);
     this.getRecord = this.getRecord.bind(this);
     this.getItems = this.getItems.bind(this);
@@ -32,41 +36,78 @@ class ResultsList extends React.Component {
     this.context.router.push(route);
   }
 
+  showMoreItems(e, id){
+    e.preventDefault();
+
+    const expandedItems = this.state.expandedItems;
+    expandedItems.push(id);
+    this.setState({ expandedItems: expandedItems });
+  }
+
   getItems(items, result) {
+    const itemCount = items.length;
+    const maxDisplay = 5;
+    const moreCount = itemCount - maxDisplay;
+    const expandedItems = this.state.expandedItems;
+    const resultId = result.idBnum;
+
+    // available items first
+    items.sort((a, b) => {
+      const aAvailability = a.availability[0].substring(7) === 'AVAILABLE' ? -1 : 1;
+      const bAvailability = b.availability[0].substring(7) === 'AVAILABLE' ? -1 : 1;
+      return aAvailability - bAvailability;
+    });
+
     return items.map((item, i) => {
       const availability = item.availability[0].substring(7);
       const available = availability === 'AVAILABLE';
       const id = item['@id'].substring(4);
+      const availabilityClassname = availability.replace(/\W/g, '').toLowerCase();
+      const collapsed = expandedItems.indexOf(resultId) < 0
 
       return (
-        <div className="sub-item" key={i}>
-          <div>
-            <span className="status available">{availability}</span>
-            {
-              available ? ' to use in ' : ''
-            }
-            <a href="#">{item.location.length ? item.location[0][0].prefLabel : null}</a>
-            {
-              result.idCallNum ? 
-              (<span className="call-no"> with call no. {result.idCallNum[0]}</span>)
-              : null
-            }
-          </div>
-          <div>
-            {
-              available ?
-                (
-                  <Link
-                    className="button"
-                    to={`/hold/${id}`}
-                    onClick={(e) => this.getRecord(e, id, 'hold')}
-                  >
-                    Place a hold
-                  </Link>
-                )
+        <div key={i}>
+          <div className={`sub-item ${i>=maxDisplay && collapsed ? 'more' : ''}`}>
+            <div>
+              <span className={`status ${availabilityClassname}`}>{availability}</span>
+              {
+                available ? ' to use in ' : ' '
+              }
+              <a href="#">{item.location.length ? item.location[0][0].prefLabel : null}</a>
+              {
+                result.idCallNum ?
+                (<span className="call-no"> with call no. {result.idCallNum[0]}</span>)
                 : null
-            }
+              }
+            </div>
+            <div>
+              {
+                available ?
+                  (
+                    <Link
+                      className="button"
+                      to={`/hold/${id}`}
+                      onClick={(e) => this.getRecord(e, id, 'hold')}
+                    >
+                      Place a hold
+                    </Link>
+                  )
+                  : null
+              }
+            </div>
           </div>
+          {
+            i >= itemCount - 1 && moreCount > 0 && collapsed ?
+              (
+                <Link
+                  onClick={(e) => this.showMoreItems(e, resultId)}
+                  href="#see-more"
+                  className="see-more-link">
+                  See {moreCount} more item{moreCount > 1 ? 's' : ''}
+                </Link>
+              )
+              : null
+          }
         </div>
       );
     });
@@ -85,7 +126,7 @@ class ResultsList extends React.Component {
             <img src={result.btCover} />
           </div>
           ) : null;
-        const authors = result.contributor && result.contributor.length ? 
+        const authors = result.contributor && result.contributor.length ?
           result.contributor.map((author) => `${author}; ` )
           : null;
         const id = result.idBnum;

--- a/src/client/styles/components/Item.scss
+++ b/src/client/styles/components/Item.scss
@@ -52,6 +52,12 @@
   }
 }
 
+.holdings-table {
+  .collapsed {
+      display: none;
+  }
+}
+
 .hiearchy {
   a {
     display: block;

--- a/src/client/styles/components/Results.scss
+++ b/src/client/styles/components/Results.scss
@@ -142,12 +142,22 @@
     }
 
     .sub-items {
+      margin-top: 0.35rem;
+      max-width: 800px;
+
+      .see-more-link {
+        display: block;
+        padding: 0.2rem 0.5rem;
+        border-top: 1px solid $lightgray;
+        background: $lightgray;
+      }
+    }
+
+    .sub-items > div {
       display: table;
       width: 100%;
-      max-width: 800px;
       // border: 1px solid $lightgray;
       padding: 0;
-      margin-top: 0.35rem;
       background: lighten($lightergray, 4%);
     }
 


### PR DESCRIPTION
- Create a "See (x) more items" link under bibs that have many items. 
- I added this to the search results page (limit is 5) as well as the item page (limit is 7).
- With this change, I also sorted the items based on availability, i.e. status "Available" will always be on top
- I also changed the colors for non-available items
- The implementation on the search results page is not ideal-- the sub-item list should probably be broken up into its own component, but we can refactor after the alpha is shipped if it doesn't mess anything else up  