### PR TITLE
Add location data to hold request and confirmation pages

### DIFF
--- a/locationCodes.js
+++ b/locationCodes.js
@@ -1,0 +1,626 @@
+export default {
+  "maln1": {
+    "delivery_location": "maln",
+    "location": "schwarzman"
+  },
+  "rcmf8": {
+    "delivery_location": "maf",
+    "location": "schwarzman"
+  },
+  "scf": {
+    "delivery_location": "sc",
+    "location": "schomburg"
+  },
+  "malm2": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "rcmr2": {
+    "delivery_location": "mar92",
+    "location": "schwarzman"
+  },
+  "mal92": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "marr2": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  },
+  "mard2": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  },
+  "mab98": {
+    "delivery_location": "mab",
+    "location": "schwarzman"
+  },
+  "mab99": {
+    "delivery_location": "mab",
+    "location": "schwarzman"
+  },
+  "mab92": {
+    "delivery_location": "mab",
+    "location": "schwarzman"
+  },
+  "maf98": {
+    "delivery_location": "maf",
+    "location": "schwarzman"
+  },
+  "maf99": {
+    "delivery_location": "maf",
+    "location": "schwarzman"
+  },
+  "rccb2": {
+    "delivery_location": "",
+    "location": "schomburg"
+  },
+  "maf92": {
+    "delivery_location": "maf",
+    "location": "schwarzman"
+  },
+  "myh22": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "rccb9": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  },
+  "rccb8": {
+    "delivery_location": "",
+    "location": "schomburg"
+  },
+  "rcmj2": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "rccd2": {
+    "delivery_location": "",
+    "location": "schomburg"
+  },
+  "rccd9": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  },
+  "qcmp2": {
+    "delivery_location": "map",
+    "location": "schwarzman"
+  },
+  "rc2mj": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "rcms2": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  },
+  "rc2ma": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "myd22": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "mar82": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  },
+  "rcmb9": {
+    "delivery_location": "mab",
+    "location": "schwarzman"
+  },
+  "rcmb8": {
+    "delivery_location": "mab",
+    "location": "schwarzman"
+  },
+  "mym42": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "mas62": {
+    "delivery_location": "mab",
+    "location": "schwarzman"
+  },
+  "magg1": {
+    "delivery_location": "mag",
+    "location": "schwarzman"
+  },
+  "rcmb2": {
+    "delivery_location": "mab",
+    "location": "schwarzman"
+  },
+  "magh1": {
+    "delivery_location": "mag",
+    "location": "schwarzman"
+  },
+  "rcpf2": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "myh32": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "mao92": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  },
+  "myt22": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "rcce2": {
+    "delivery_location": "",
+    "location": "schomburg"
+  },
+  "rcmp2": {
+    "delivery_location": "map",
+    "location": "schwarzman"
+  },
+  "rcmq2": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  },
+  "rcce8": {
+    "delivery_location": "",
+    "location": "schomburg"
+  },
+  "rcce9": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  },
+  "mapp3": {
+    "delivery_location": "map",
+    "location": "schwarzman"
+  },
+  "mapp2": {
+    "delivery_location": "map",
+    "location": "schwarzman"
+  },
+  "mapp1": {
+    "delivery_location": "map",
+    "location": "schwarzman"
+  },
+  "rcph2": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "maii1": {
+    "delivery_location": "mai",
+    "location": "schwarzman"
+  },
+  "maii3": {
+    "delivery_location": "mai",
+    "location": "schwarzman"
+  },
+  "maii2": {
+    "delivery_location": "mai",
+    "location": "schwarzman"
+  },
+  "mabm2": {
+    "delivery_location": "mab",
+    "location": "schwarzman"
+  },
+  "qcml2": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "qcmy2": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "rc2sl": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "rc": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "mao82": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  },
+  "qcms2": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "myt32": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "magg3": {
+    "delivery_location": "mag",
+    "location": "schwarzman"
+  },
+  "magg2": {
+    "delivery_location": "mag",
+    "location": "schwarzman"
+  },
+  "rccf2": {
+    "delivery_location": "",
+    "location": "schomburg"
+  },
+  "qcmb8": {
+    "delivery_location": "mab",
+    "location": "schwarzman"
+  },
+  "qcmb9": {
+    "delivery_location": "mab",
+    "location": "schwarzman"
+  },
+  "rc2cm": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "qcmb2": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "rccf9": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  },
+  "rccf8": {
+    "delivery_location": "",
+    "location": "schomburg"
+  },
+  "scff3": {
+    "delivery_location": "sc",
+    "location": "schomburg"
+  },
+  "scff2": {
+    "delivery_location": "sc",
+    "location": "schomburg"
+  },
+  "scff1": {
+    "delivery_location": "sc",
+    "location": "schomburg"
+  },
+  "rc2cf": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "slr12": {
+    "delivery_location": "slr",
+    "location": "sibl"
+  },
+  "qcmf9": {
+    "delivery_location": "maf",
+    "location": "schwarzman"
+  },
+  "myrs": {
+    "delivery_location": "myrs",
+    "location": "lpa"
+  },
+  "maff3": {
+    "delivery_location": "maf",
+    "location": "schwarzman"
+  },
+  "maff1": {
+    "delivery_location": "maf",
+    "location": "schwarzman"
+  },
+  "os": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "myd42": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "qc2sl": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "rcmi2": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  },
+  "mai92": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "rcxx2": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  },
+  "rcma2": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "maor2": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  },
+  "qcmr2": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  },
+  "rccd8": {
+    "delivery_location": "",
+    "location": "schomburg"
+  },
+  "qcmj2": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "mag92": {
+    "delivery_location": "mag",
+    "location": "schwarzman"
+  },
+  "rcpd9": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "mag98": {
+    "delivery_location": "mag",
+    "location": "schwarzman"
+  },
+  "rcpr9": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "qc2ma": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "mai87": {
+    "delivery_location": "mai",
+    "location": "schwarzman"
+  },
+  "rcpr2": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "myd32": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "map82": {
+    "delivery_location": "map",
+    "location": "schwarzman"
+  },
+  "qc2mj": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "rcpm2": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "rcsl2": {
+    "delivery_location": "slr",
+    "location": "sibl"
+  },
+  "mag82": {
+    "delivery_location": "mag",
+    "location": "schwarzman"
+  },
+  "mab62": {
+    "delivery_location": "mab",
+    "location": "schwarzman"
+  },
+  "rcmf2": {
+    "delivery_location": "maf",
+    "location": "schwarzman"
+  },
+  "mag": {
+    "delivery_location": "mag",
+    "location": "schwarzman"
+  },
+  "malw": {
+    "delivery_location": "malw",
+    "location": "schwarzman"
+  },
+  "rcmf9": {
+    "delivery_location": "maf",
+    "location": "schwarzman"
+  },
+  "qcmi2": {
+    "delivery_location": "mai",
+    "location": "schwarzman"
+  },
+  "slr": {
+    "delivery_location": "slr",
+    "location": "sibl"
+  },
+  "maln": {
+    "delivery_location": "maln",
+    "location": "schwarzman"
+  },
+  "malv2": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "qcma2": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "slr22": {
+    "delivery_location": "slr",
+    "location": "sibl"
+  },
+  "malc": {
+    "delivery_location": "malc",
+    "location": "schwarzman"
+  },
+  "mala": {
+    "delivery_location": "mala",
+    "location": "schwarzman"
+  },
+  "mabb3": {
+    "delivery_location": "mab",
+    "location": "schwarzman"
+  },
+  "mabb2": {
+    "delivery_location": "mab",
+    "location": "schwarzman"
+  },
+  "mabb1": {
+    "delivery_location": "mab",
+    "location": "schwarzman"
+  },
+  "rcca9": {
+    "delivery_location": "sccc3",
+    "location": "schwarzman"
+  },
+  "rcpd8": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "qcmg2": {
+    "delivery_location": "mag",
+    "location": "schwarzman"
+  },
+  "map92": {
+    "delivery_location": "map",
+    "location": "schwarzman"
+  },
+  "myr": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "rcpd2": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "qcmg8": {
+    "delivery_location": "mag",
+    "location": "schwarzman"
+  },
+  "mym32": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "rcmo2": {
+    "delivery_location": "mao92",
+    "location": "schwarzman"
+  },
+  "rcmg2": {
+    "delivery_location": "mag",
+    "location": "schwarzman"
+  },
+  "mar92": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  },
+  "rcmg8": {
+    "delivery_location": "mag",
+    "location": "schwarzman"
+  },
+  "rcmg9": {
+    "delivery_location": "maf",
+    "location": "schwarzman"
+  },
+  "myh42": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "malw1": {
+    "delivery_location": "malw",
+    "location": "schwarzman"
+  },
+  "map": {
+    "delivery_location": "map",
+    "location": "schwarzman"
+  },
+  "mar": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  },
+  "qcmf2": {
+    "delivery_location": "maf",
+    "location": "schwarzman"
+  },
+  "mas82": {
+    "delivery_location": "mab",
+    "location": "schwarzman"
+  },
+  "rcpt8": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "mai82": {
+    "delivery_location": "mai",
+    "location": "schwarzman"
+  },
+  "qcmf8": {
+    "delivery_location": "maf",
+    "location": "schwarzman"
+  },
+  "mai83": {
+    "delivery_location": "mai",
+    "location": "schwarzman"
+  },
+  "mal82": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "mym22": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "mab": {
+    "delivery_location": "mab",
+    "location": "schwarzman"
+  },
+  "mar62": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  },
+  "mall1": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "maf": {
+    "delivery_location": "maf",
+    "location": "schwarzman"
+  },
+  "mai": {
+    "delivery_location": "mai",
+    "location": "schwarzman"
+  },
+  "rcml2": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "rcpt2": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "mal": {
+    "delivery_location": "mal",
+    "location": "schwarzman"
+  },
+  "mao": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  },
+  "myt42": {
+    "delivery_location": "myr",
+    "location": "lpa"
+  },
+  "mab82": {
+    "delivery_location": "mab",
+    "location": "schwarzman"
+  },
+  "maf88": {
+    "delivery_location": "maf",
+    "location": "schwarzman"
+  },
+  "sc": {
+    "delivery_location": "sc",
+    "location": "schomburg"
+  },
+  "maf82": {
+    "delivery_location": "maf",
+    "location": "schwarzman"
+  },
+  "qcmo2": {
+    "delivery_location": "",
+    "location": "schwarzman"
+  }
+}

--- a/locations.js
+++ b/locations.js
@@ -1,0 +1,110 @@
+export default {
+  "lpa": {
+    "id": "55",
+    "full-name": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center",
+    "short-name": "Library for the Performing Arts",
+    "symbol": "LPA",
+    "slug": "lpa",
+    "phone": "(917) 275-6975",
+    "uri": "http://www.nypl.org/about/locations/lpa",
+    "address": {
+      "address1": "40 Lincoln Center Plaza",
+      "address2": "",
+      "city": "New York",
+      "postal-code": "10023",
+      "latitude": 40.7735,
+      "longitude": -73.9848,
+      "map-embed-uri": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3021.488259006964!2d-73.98695534929564!3d40.77327884170035!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89c258f580711f93%3A0x9750fe4e405f3666!2sNew+York+Public+Library!5e0!3m2!1sen!2sus!4v1479242693558"
+    },
+    "hours": [
+      {"day": "Sunday", "closed": true},
+      {"day": "Monday", "open": "10:30 AM", "close": "8 PM"},
+      {"day": "Tuesday", "open": "10:30 AM", "close": "6 PM"},
+      {"day": "Wednesday", "open": "10:30 AM", "close": "6 PM"},
+      {"day": "Thursday", "open": "10:30 AM", "close": "8 PM"},
+      {"day": "Friday", "open": "10:30 AM", "close": "6 PM"},
+      {"day": "Saturday", "open": "10:30 AM", "close": "6 PM"}
+    ]
+  },
+  "schomburg": {
+    "id": "64",
+    "full-name": "Schomburg Center for Research in Black Culture",
+    "short-name": "Schomburg Center",
+    "symbol": "SC",
+    "slug": "schomburg",
+    "phone": "(917) 275-6975",
+    "uri": "http://www.nypl.org/about/locations/schomburg",
+    "address": {
+      "address1": "515 Malcolm X Boulevard",
+      "address2": "",
+      "city": "New York",
+      "postal-code": "10037",
+      "latitude": 40.8144,
+      "longitude": -73.941,
+      "map-embed-uri": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3019.608723918744!2d-73.94312004929432!3d40.8145912391688!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89c2f676c762ebed%3A0x74444bd477cfdf28!2sSchomburg+Center+for+Research+in+Black+Culture!5e0!3m2!1sen!2sus!4v1479242810413"
+    },
+    "hours": [
+      {"day": "Sunday", "closed": true},
+      {"day": "Monday", "open": "10 AM", "close": "6 PM"},
+      {"day": "Tuesday", "open": "10 AM", "close": "8 PM"},
+      {"day": "Wednesday", "open": "10 AM", "close": "8 PM"},
+      {"day": "Thursday", "open": "10 AM", "close": "6 PM"},
+      {"day": "Friday", "open": "10 AM", "close": "6 PM"},
+      {"day": "Saturday", "open": "10 AM", "close": "6 PM"}
+    ]
+  },
+  "schwarzman": {
+    "id": "36",
+    "full-name": "Stephen A. Schwarzman Building",
+    "short-name": "Schwarzman Building",
+    "symbol": "SASB",
+    "slug": "schwarzman",
+    "phone": "(917) 275-6975",
+    "uri": "http://www.nypl.org/about/locations/schwarzman",
+    "address": {
+      "address1": "476 Fifth Avenue (42nd St and Fifth Ave)",
+      "address2": "",
+      "city": "New York",
+      "postal-code": "10018",
+      "latitude": 40.7532,
+      "longitude": -73.9822,
+      "map-embed-uri": "https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d3022.3899875663374!2d-73.98487169126284!3d40.7534464793701!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x3b51df6e509a734c!2sNew+York+Public+Library+-+Stephen+A.+Schwarzman+Building!5e0!3m2!1sen!2sus!4v1476394300850"
+    },
+    "hours": [
+      {"day": "Sunday", "open": "1 PM", "close": "5 PM"},
+      {"day": "Monday", "open": "10 AM", "close": "6 PM"},
+      {"day": "Tuesday", "open": "10 AM", "close": "8 PM"},
+      {"day": "Wednesday", "open": "10 AM", "close": "8 PM"},
+      {"day": "Thursday", "open": "10 AM", "close": "6 PM"},
+      {"day": "Friday", "open": "10 AM", "close": "6 PM"},
+      {"day": "Saturday", "open": "10 AM", "close": "6 PM"}
+    ]
+  },
+  "sibl": {
+    "id": "65",
+    "full-name": "Science, Industry and Business Library (SIBL)",
+    "short-name": "SIBL",
+    "symbol": "SIBL",
+    "slug": "sibl",
+    "phone": "(917) 275-6975",
+    "uri": "http://www.nypl.org/about/locations/sibl",
+    "address": {
+      "address1": "188 Madison Avenue @ 34th Street",
+      "address2": "",
+      "city": "New York",
+      "postal-code": "10016",
+      "latitude": 40.748,
+      "longitude": -73.983,
+      "map-embed-uri": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3022.6251650256686!2d-73.98516884929633!3d40.74827274323163!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89c259077e416ac5%3A0x7e268f9deac6bdf6!2sScience%2C+Industry+and+Business+Library+-+NYPL!5e0!3m2!1sen!2sus!4v1479242773380"
+    },
+    "hours": [
+      {"day": "Sunday", "closed": true},
+      {"day": "Monday", "open": "10 AM", "close": "6 PM"},
+      {"day": "Tuesday", "open": "10 AM", "close": "8 PM"},
+      {"day": "Wednesday", "open": "10 AM", "close": "8 PM"},
+      {"day": "Thursday", "open": "10 AM", "close": "8 PM"},
+      {"day": "Friday", "open": "10 AM", "close": "6 PM"},
+      {"day": "Saturday", "open": "10 AM", "close": "6 PM"}
+    ]
+  }
+}

--- a/src/app/components/HoldPage/HoldConfirmation.jsx
+++ b/src/app/components/HoldPage/HoldConfirmation.jsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router';
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs.jsx';
 import Tabs from '../Tabs/Tabs.jsx';
 import TabPanel from '../Tabs/TabPanel.jsx';
+import LibraryItem from '../../utils/item.js';
 
 class HoldConfirmation extends React.Component {
   render() {
@@ -13,6 +14,8 @@ class HoldConfirmation extends React.Component {
     } = this.props;
     const title = item.title[0];
     const id = item['@id'].substring(4);
+    const selectedItem = LibraryItem.getItem(item, this.props.params.id);
+    const location = LibraryItem.getLocation(item, this.props.params.id);
 
     const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'June', 'July',
       'Aug', 'Sept', 'Oct', 'Nov', 'Dec'];
@@ -46,9 +49,14 @@ class HoldConfirmation extends React.Component {
             <div className="details col span-2-3">
               <h2>Item request details</h2>
               <ul className="generic-list">
-                <li>You have requested a hold on <Link to={`/item/${id}`}>{title}</Link></li>
+                <li>Item: <Link to={`/item/${id}`}>{title}</Link></li>
+                {selectedItem.shelfMark &&
+                  <li>
+                    Call number: {selectedItem.shelfMark[0]}
+                  </li>
+                }
                 { /* <li>Ready for use by <strong>approximately {dateDisplay}, 9:00am</strong> at the location below</li> */ }
-                <li><strong>You will receive an email notification</strong> when the item is ready for use</li>
+                <li><strong>You will receive an email notification</strong> when the item is ready for use at the location below</li>
                 { /* <li>Book will be held until {dateDisplayEnd}, 5:00pm</li> */ }
                 <li>Visit your <a href="#">patron account page</a> to view the status of this item hold</li>
               </ul>
@@ -57,7 +65,7 @@ class HoldConfirmation extends React.Component {
               <h2>Available actions</h2>
               <ul className="generic-list">
                 <li>Visit your <Link to="/account/holds">patron account page</Link> to view the status of this item hold</li>
-                <li>You may <a href="#cancel">cancel</a> this item hold at any time</li>
+                { /* <li>You may <a href="#cancel">cancel</a> this item hold at any time</li> */ }
               </ul>
             </div>
           </div>
@@ -71,7 +79,7 @@ class HoldConfirmation extends React.Component {
                 ]}
               >
                 <TabPanel id="building">
-                  <iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d3022.3899875663374!2d-73.98487169126284!3d40.7534464793701!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x3b51df6e509a734c!2sNew+York+Public+Library+-+Stephen+A.+Schwarzman+Building!5e0!3m2!1sen!2sus!4v1476394300850" height="450" frameBorder="0" style={{border: 0}} allowFullScreen></iframe>
+                  <iframe src={`${location.address["map-embed-uri"]}`} height="450" frameBorder="0" style={{border: 0}} allowFullScreen></iframe>
                 </TabPanel>
                 <TabPanel id="room">
                   <img src="/src/client/images/floor_plan.png" alt="Floor plan of first floor of Stephen A. Schwarzman Building" />
@@ -79,19 +87,31 @@ class HoldConfirmation extends React.Component {
               </Tabs>
             </div>
             <div className="col span-2-5">
-              <p><a href="https://www.nypl.org/locations/schwarzman">Stephen A. Schwarzman Building</a><br />
-              <a href="https://www.google.com/maps/place/New+York+Public+Library+-+Stephen+A.+Schwarzman+Building/@40.7536903,-73.9858051,17z/data=!3m1!5s0x89c259006f811e69:0xdf9c5a032104b840!4m13!1m7!3m6!1s0x89c259aa982c98b1:0x82f102a365e99b51!2s476+5th+Ave,+New+York,+NY+10018!3b1!8m2!3d40.7536863!4d-73.9836111!3m4!1s0x0:0x3b51df6e509a734c!8m2!3d40.7531821!4d-73.9822534">476 Fifth Avenue</a> (42nd St and Fifth Ave)<br />New York, NY 10018<br />
-              <a href="https://www.nypl.org/locations/divisions/milstein">Milstein Division</a>, First Floor, Room 121</p>
+              <p>
+                <a href={`${location.uri}`}>{location["full-name"]}</a><br />
+                {location.address.address1}<br />
+                {location.prefLabel}
+              </p>
               <p>Regular hours:</p>
               <table className="generic-table">
                 <tbody>
-                  <tr><td>Sunday</td><td>1 PM–5 PM</td></tr>
-                  <tr><td>Monday</td><td>10 AM–6 PM</td></tr>
-                  <tr><td>Tuesday</td><td>10 AM–8 PM</td></tr>
-                  <tr><td>Wednesday</td><td>10 AM–8 PM</td></tr>
-                  <tr><td>Thursday</td><td>10 AM–6 PM</td></tr>
-                  <tr><td>Friday</td><td>10 AM–6 PM</td></tr>
-                  <tr><td>Saturday</td><td>10 AM–6 PM</td></tr>
+                  {
+                    location.hours.map((h, i) => (
+                      <tr key={i}>
+                        <td>{h.day}</td>
+                          {!h.closed &&
+                            <td>
+                              {h.open} - {h.close}
+                            </td>
+                          }
+                          {h.closed &&
+                            <td>
+                            <em>Closed</em>
+                            </td>
+                          }
+                      </tr>
+                    ))
+                  }
                 </tbody>
               </table>
             </div>

--- a/src/app/components/HoldPage/HoldConfirmation.jsx
+++ b/src/app/components/HoldPage/HoldConfirmation.jsx
@@ -58,13 +58,12 @@ class HoldConfirmation extends React.Component {
                 { /* <li>Ready for use by <strong>approximately {dateDisplay}, 9:00am</strong> at the location below</li> */ }
                 <li><strong>You will receive an email notification</strong> when the item is ready for use at the location below</li>
                 { /* <li>Book will be held until {dateDisplayEnd}, 5:00pm</li> */ }
-                <li>Visit your <a href="#">patron account page</a> to view the status of this item hold</li>
               </ul>
             </div>
             <div className="actions col span-1-3">
               <h2>Available actions</h2>
               <ul className="generic-list">
-                <li>Visit your <Link to="/account/holds">patron account page</Link> to view the status of this item hold</li>
+                <li>Visit your <a href="http://myaccount-beta.nypl.org/my-account/holds">patron account page</a> to view the status of this item hold</li>
                 { /* <li>You may <a href="#cancel">cancel</a> this item hold at any time</li> */ }
               </ul>
             </div>

--- a/src/app/components/HoldRequest/HoldRequest.jsx
+++ b/src/app/components/HoldRequest/HoldRequest.jsx
@@ -5,6 +5,7 @@ import Breadcrumbs from '../Breadcrumbs/Breadcrumbs.jsx';
 import Store from '../../stores/Store.js';
 import PatronData from '../../stores/PatronData.js';
 import config from '../../../../appConfig.js';
+import LibraryItem from '../../utils/item.js';
 
 class HoldRequest extends React.Component {
   constructor(props) {
@@ -38,25 +39,8 @@ class HoldRequest extends React.Component {
     const title = record.title[0];
     const bibId = record['@id'].substring(4);
     const itemId = this.props.params.id;
-
-    // determine item and location
-    const items = record.items;
-    const selectedItem = items.find((i) => {
-      return i['@id'].substring(4) == itemId;
-    });
-    // default to SASB - RMRR
-    const defaultLocation = {
-      '@id': 'loc:mal',
-      'prefLabel': 'SASB - Rose Main Rdg Rm 315'
-    };
-    let location = defaultLocation;
-    if (selectedItem && selectedItem.location && selectedItem.location.length > 0) {
-      location = selectedItem.location[0][0];
-    }
-    const isOffsite = location.prefLabel.substring(0,7) === "OFFSITE"
-    if (isOffsite) {
-      location = defaultLocation;
-    }
+    const selectedItem = LibraryItem.getItem(record, itemId);
+    const location = LibraryItem.getLocation(record, itemId);
 
     const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'June', 'July',
       'Aug', 'Sept', 'Oct', 'Nov', 'Dec'];
@@ -103,23 +87,25 @@ class HoldRequest extends React.Component {
             <fieldset className="select-location-fieldset">
               <label className="group selected" htmlFor="location1">
                 <span className="col location">
-                  {isOffsite &&
+                  <a href={`${location.uri}`}>{location["full-name"]}</a><br />{location.address.address1}<br />
+                  {location.prefLabel}
+                  {location.offsite &&
                     <span>
-                      {location.prefLabel}
-                      <br /><small>(requested from offsite storage)</small>
+                      <br /><small>(requested from offsite storage)</small><br />
                     </span>
                   }
-                  {!isOffsite && location.prefLabel}
-                  {/*<a href="https://www.nypl.org/locations/schwarzman">Schwarzman Building</a>, 476 Fifth Avenue at 42nd, New York, NY,
-                  <a href="https://www.nypl.org/locations/divisions/milstein">Milstein Division</a>, First Floor, Room 120
-                  */}
+                  {/*<a href="https://www.nypl.org/locations/divisions/milstein">Milstein Division</a>, First Floor, Room 120*/}
                 </span>
-                <span className="col"><small>Call number:</small><br />{selectedItem.shelfMark[0]}</span>
+                {selectedItem.shelfMark &&
+                  <span className="col">
+                    <small>Call number:</small><br />{selectedItem.shelfMark[0]}
+                  </span>
+                }
                 {/*<span className="col"><small>Ready by approximately:</small><br />{dateDisplay}, 9am.</span>*/}
               </label>
             </fieldset>
 
-            <input type="hidden" name="pickupLocation" value={location['@id'].substring(4)} />
+            <input type="hidden" name="pickupLocation" value={location.code} />
 
             <button type="submit" className="large">
               Submit your item hold request

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -1,0 +1,73 @@
+import Locations from '../../../locations.js';
+import LocationCodes from '../../../locationCodes.js';
+
+function LibraryItem() {
+
+  /**
+   * getItem(record, 'b18207658-i24609501')
+   * @param (Object) record
+   * @param (String) itemId
+   */
+  this.getItem = (record, itemId) => {
+    // look for item id in record's items
+    const items = record.items;
+    let thisItem = {};
+    items.forEach((i) => {
+      if (i['@id'].substring(4) == itemId) {
+        thisItem = i;
+      }
+    });
+    return thisItem;
+  };
+
+  /**
+   * getLocation(record, 'b18207658-i24609501')
+   * @param (Object) record
+   * @param (String) itemId
+   */
+  this.getLocation = (record, itemId) => {
+    const thisItem = this.getItem(record, itemId);
+
+    // default to SASB - RMRR
+    const defaultLocation = {
+      '@id': 'loc:mal',
+      'prefLabel': 'SASB - Rose Main Rdg Rm 315'
+    };
+
+    // get location and location code
+    let location = defaultLocation;
+    if (thisItem && thisItem.location && thisItem.location.length > 0) {
+      location = thisItem.location[0][0];
+    }
+    const locationCode = location['@id'].substring(4);
+    const prefLabel = location.prefLabel;
+    const isOffsite = prefLabel.substring(0,7).toLowerCase() === "offsite"
+
+    // retrieve location data
+    if (locationCode in LocationCodes) {
+      location = Locations[LocationCodes[locationCode].location];
+    } else {
+      location = Locations[LocationCodes[defaultLocation['@id'].substring(4)].location];
+    }
+
+    // retrieve delivery location
+    let deliveryLocationCode = defaultLocation['@id'].substring(4)
+    if (locationCode in LocationCodes) {
+      deliveryLocationCode = LocationCodes[locationCode].delivery_location;
+    }
+
+    location.offsite = isOffsite;
+    location.code = deliveryLocationCode;
+    location.prefLabel = prefLabel;
+
+    console.log()
+    if (isOffsite && deliveryLocationCode === defaultLocation['@id'].substring(4)) {
+      location.prefLabel = defaultLocation.prefLabel;
+    }
+
+    return location;
+  };
+
+}
+
+export default new LibraryItem;

--- a/src/server/ApiRoutes/ApiRoutes.js
+++ b/src/server/ApiRoutes/ApiRoutes.js
@@ -318,7 +318,7 @@ function NewHoldRequest(req, res, next){
   RetrieveItem(
     req.params.id ,
     (data) => {
-      console.log('Item data', data)
+      // console.log('Item data', data)
       res.locals.data.Store = {
         item: data,
         searchKeywords: '',


### PR DESCRIPTION
I added location-related data to the hold request and the hold confirmation pages (#24)

This includes:
- the full name of the building
- the address of the building
- the embedded map
- the hours

Some sample items for testing (e.g. `/hold/request/{id}`, and `/hold/confirmation/{id}`):
Offsite Princeton - b17667243-i22519773
Offsite - b18887197-i26265219
Schomburg - b11215031-i12061804
SASB - b18535586-i25384231
LPA - b11152464-i14946890
SIBL - b13775477-i16838667

I implemented this by hard-coding the location mappings (location codes -> location) and location data (I added embed code and hours) since there's only 4 research centers.  For the long-term implementation, this should come from the API.

Other things for future work:
- Directions to room not yet implemented
- Hours is for the building, but ideally this should be to the specific research room that the item is being delivered to
