### PR TITLE
Catch expired cookie (server-side)

### DIFF
--- a/src/server/routes/auth/index.js
+++ b/src/server/routes/auth/index.js
@@ -14,9 +14,10 @@ export function initializeTokenAuth(req, res, next) {
           isTokenValid: false,
           errorCode: error.message,
         };
-        next();
+        return next();
         // res.redirect(`${config.loginUrl}?redirect_uri=http://local.nypl.org:3001/my-account/holds`);
       }
+
       // Token has been verified, initialize user session
       req.tokenResponse = {
         isTokenValid: true,
@@ -25,7 +26,7 @@ export function initializeTokenAuth(req, res, next) {
         errorCode: null,
       };
       // Continue next function call
-      next();
+      return next();
     });
   } else {
     // Token is undefined from the cookie


### PR DESCRIPTION
Returning next() when oauth token fails to initialize so the app doesn't crash and can continue to make requests.

This is a server side fix. When the token expires, the browser's console will still display an error but that's from the Header which is kind of out of our control. I added a comment and suggestion regarding updating that in Kang's current [Header PR](https://bitbucket.org/NYPL/dgx-header-component/pull-requests/84/update-log-out-link/diff). Even though there's an error in the console. searching should work as expected.