### PR TITLE
added related formats and editions to item page based on workid

### DIFF
--- a/src/app/components/ItemPage/ItemEditions.jsx
+++ b/src/app/components/ItemPage/ItemEditions.jsx
@@ -1,34 +1,37 @@
 import React from 'react';
+import axios from 'axios';
+
+import ResultList from '../Results/ResultsList.jsx';
 
 class ItemEditions extends React.Component {
-  getImage(url) {
-    if (!url) {
-      return null;
-    }
 
-    return (
-      <div className="result-image">
-        <img src={url} alt="" />
-      </div>
-    );
+  constructor(props) {
+    super(props);
+
+    this.state ={
+      results: []
+    };
   }
 
-  getItem(data) {
-    if (!data.length) {
-      return null;
-    }
+  componentWillMount() {
+    const record = this.props.item;
+    const idOwi = record.idOwi && record.idOwi.length ? record.idOwi[0] : null;
 
-    return data.map((item, i) => {
-      return (
-        <div className="result-item" key={i}>
-          {this.getImage(item.imgUrl)}
-          <div className="result-text">
-            <a href="#" className="title">{item.title}</a>
-            <div className="description" dangerouslySetInnerHTML={this.createMarkup(item.description)}></div>
-          </div>
-        </div>
-      );
-    });
+    if (idOwi) {
+      axios
+        .get(`http://discovery-api.nypltech.org/api/v1/resources?q=${encodeURIComponent(`idOwi:"${idOwi}"`)}`)
+        .then(response => {
+          if (response.data && response.data.itemListElement && response.data.itemListElement.length) {
+            const results = response.data.itemListElement.filter((item, i) => { return item.result['@id'] != record['@id']; });
+            if (results.length) {
+              this.setState({ results: results });
+            }
+          }
+        })
+        .catch(error => {
+          console.log(error);
+        });
+    }
   }
 
   createMarkup(markup) {
@@ -36,43 +39,17 @@ class ItemEditions extends React.Component {
   }
 
   render() {
-    const data = [
-      {
-        imgUrl: '../img/federalist_papers_macmillan.jpg',
-        title: 'The Federalist papers: edited by and with an introduction by Michael A. Genovese',
-        description: '<span>Palgrave Macmillan <span class="divider"></span> 2009 <span class="divider"></span> 1st ed.</span>',
-      },
-      {
-        imgUrl: '../img/federalist_papers_oxford.jpg',
-        title: 'The Federalist papers: edited with an introduction and notes by Lawrance Goldman',
-        description: '<span>Oxford University Press <span class="divider"></span> 2008</span>',
-      },
-      {
-        imgUrl: '../img/federalist_papers_penguin.jpg',
-        title: 'The Federalist papers: with an introduction, table of contents, and index of ideas by Clinton Rossiter',
-        description: '<span>Penguin <span class="divider"></span> 1961</span>',
-      },
-    ];
+    if (!this.state.results.length) return null;
+
     const title = this.props.title;
 
     return (
-      <div>
-        <h3>
-          <a name="editions"></a>Other editions of "{title}"
-        </h3>
+      <div className="item-details">
+        <h2>
+          <a name="editions"></a>Formats and editions related to "{title}"
+        </h2>
 
-        <div className="result-list">
-          {this.getItem(data)}
-
-          <div className="result-item more">
-            <div className="result-image">
-
-            </div>
-            <div className="result-text">
-              <a href="#more">See all of the Library's 24 editions of "{title}"</a>
-            </div>
-          </div>
-        </div>
+        <ResultList results={this.state.results} />
       </div>
     );
   }
@@ -80,6 +57,7 @@ class ItemEditions extends React.Component {
 
 ItemEditions.propTypes = {
   title: React.PropTypes.string,
+  item: React.PropTypes.object
 };
 
 export default ItemEditions;

--- a/src/app/components/ItemPage/ItemPage.jsx
+++ b/src/app/components/ItemPage/ItemPage.jsx
@@ -131,7 +131,7 @@ class ItemPageRegular extends React.Component {
               title="Item details"
             />
 
-            {/*<ItemEditions title={title} />
+            {/*
 
             <ItemDetails data={externalData} title="External data" />
 
@@ -140,6 +140,8 @@ class ItemPageRegular extends React.Component {
             <ItemDetails data={citeData} title="Cite this book" />
           */}
           </div>
+
+          <ItemEditions title={title} item={record} />
 
         </div>
       </div>

--- a/src/client/styles/components/Item.scss
+++ b/src/client/styles/components/Item.scss
@@ -50,6 +50,14 @@
     font-size: 1.2rem;
     margin-top: 2rem;
   }
+
+  .results-list {
+    margin-top: 2rem;
+    
+    li:first-child {
+      border-top: 0;
+    }
+  }
 }
 
 .holdings-table {


### PR DESCRIPTION
Added related formats/editions to the item page (#17) based on workid.  

It makes an additional API call, e.g. `http://discovery-api.nypltech.org/api/v1/resources?q=idOwi:%22urn:owi:363779508%22`

If results are > 1 (excluding self), show on the bottom of the item page using the ResultsList component