### PR TITLE
Format large numbers on search results page #74

### DIFF
--- a/src/app/components/Hits/Hits.jsx
+++ b/src/app/components/Hits/Hits.jsx
@@ -91,6 +91,7 @@ class Hits extends React.Component {
       query,
     } = this.props;
     let activeFacetsArray = [];
+    const hitsF = hits.toLocaleString();
     _mapObject(facets, (val, key) => {
       if (val.value) {
         activeFacetsArray.push({val, key});
@@ -105,7 +106,7 @@ class Hits extends React.Component {
         {
           hits !== 0 ?
           (<p>
-            Found <strong>{hits}</strong> results {keyword} {activeFacetsElm}.
+            Found <strong>{hitsF}</strong> results {keyword} {activeFacetsElm}.
           </p>)
           : (<p>No results found {keyword} {activeFacetsElm}.</p>)
         }

--- a/src/app/components/ItemPage/ItemPage.jsx
+++ b/src/app/components/ItemPage/ItemPage.jsx
@@ -123,7 +123,7 @@ class ItemPageRegular extends React.Component {
           <ItemHoldings
             path={this.props.location.search}
             holdings={holdings}
-            title={`${record.numAvailable} copies of this item are available at the following locations:`}
+            title={`${record.numAvailable} cop${record.numAvailable === 1 ? 'y' : 'ies'} of this item are available at the following locations:`}
           />
 
           <EmbeddedDocument

--- a/src/app/components/ItemPage/ItemPage.jsx
+++ b/src/app/components/ItemPage/ItemPage.jsx
@@ -123,7 +123,7 @@ class ItemPageRegular extends React.Component {
           <ItemHoldings
             path={this.props.location.search}
             holdings={holdings}
-            title={`${record.numAvailable} cop${record.numAvailable === 1 ? 'y' : 'ies'} of this item are available at the following locations:`}
+            title={`${record.numAvailable} cop${record.numAvailable === 1 ? 'y' : 'ies'} of this item ${record.numAvailable === 1 ? 'is' : 'are'} available at the following locations:`}
           />
 
           <EmbeddedDocument

--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -40,21 +40,24 @@ class Results extends React.Component {
       page,
     } = this.props;
     const perPage = 50;
-
     const pageFactor = parseInt(page, 10) * 50;
-    let displayItems = `${pageFactor - (perPage - 1)} - ${pageFactor > hits ? hits : pageFactor}`;
-    let nextPage = (hits < perPage || pageFactor > hits) 
+
+    const hitsF = hits.toLocaleString();
+    const pageFactorF = pageFactor.toLocaleString();
+
+    let displayItems = `${pageFactor - (perPage - 1)} - ${pageFactor > hits ? hitsF : pageFactorF}`;
+    let nextPage = (hits < perPage || pageFactor > hits)
       ? null : this.getPage(page, 'next');
     let prevPage = page > 1 ? this.getPage(page, 'previous') : null;
 
     if (hits < perPage) {
-      displayItems = `1 - ${hits}`;
+      displayItems = `1 - ${hitsF}`;
     }
 
     const paginationButtons = (
       <div className="pagination">
         {prevPage}
-        <span className="paginate pagination-total">{displayItems} of {hits}</span>
+        <span className="paginate pagination-total">{displayItems} of {hitsF}</span>
         {nextPage}
       </div>
     );


### PR DESCRIPTION
Minor formatting changes:

Search results page: Format large numbers for "hits" number
Item page: plural/singular check for "copy" / "copies"
