### PR TITLE
Adding nyc as the code coverage tool and setting up npm commands to run it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 npm-debug.log
 .DS_STORE
 ebscoConfig.js
+coverage
+.nyc_output

--- a/README.md
+++ b/README.md
@@ -31,5 +31,34 @@ To run locally in production mode run
 
 and visit `localhost:3001`.
 
+## Testing
+
+### Unit Tests
+Unit tests are currently written in the [Mocha](https://mochajs.org/) testing framework. [Chai](http://chaijs.com/) is used as the assertion library and [Enzyme](http://airbnb.io/enzyme/) is used as the React testing utility.
+
+The tests can be found in the `test` folder.
+
+To run all the tests once, run
+
+    $ npm run test
+
+To run the tests continuously for active development, run
+
+    $ npm run test-dev
+
+### Code Coverage
+[Istanbul](https://istanbul.js.org/) is used for checking code coverage.
+
+To run the code coverage tool and view a quick report, run
+
+    $ npm run coverage
+
+To run the code coverage tool and view a better report, run
+
+    $ npm run coverage-report
+
+This last command will create a folder called `coverage` in the root directory. You can open up `coverage/lcov-report/index.html` in a browser to see more details about what lines of codes have not been tested.
+
+## Misc
 
 Starting up from a [Node/React boilerplate](https://bitbucket.org/NYPL/dgx-nypl-react-boilerplate).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "start": "node index",
     "dist": "NODE_ENV=production webpack --config webpack.config.js",
     "postinstall": "npm run dist",
-    "test": "node_modules/.bin/mocha --compilers js:babel-core/register"
+    "test": "node_modules/.bin/mocha --compilers js:babel-core/register",
+    "test-dev": "node_modules/.bin/mocha -w test/helpers/browser.js test/*.test.js",
+    "coverage": "BABEL_ENV=test node_modules/.bin/nyc npm test",
+    "coverage-report": "BABEL_ENV=test node_modules/.bin/nyc report --reporter=lcov"
   },
   "repository": {
     "type": "git",
@@ -25,7 +28,24 @@
   "bugs": {
     "url": "https://github.com//issues"
   },
-  "devDependencies": {},
+  "nyc": {
+    "extension": [
+      ".jsx"
+    ],
+    "require": [
+      "babel-register"
+    ]
+  },
+  "babel": {
+    "env": {
+      "test": {
+        "plugins": ["instanbul"]
+      }
+    }
+  },
+  "devDependencies": {
+    "nyc": "^9.0.1"
+  },
   "dependencies": {
     "@nypl/dgx-header-component": "git+https://git@bitbucket.org/NYPL/dgx-header-component#update-log-out-link",
     "@nypl/dgx-react-footer": "0.3.0",
@@ -33,10 +53,11 @@
     "axios": "^0.9.1",
     "babel-core": "^6.5.2",
     "babel-loader": "^6.2.3",
+    "babel-plugin-istanbul": "^3.0.0",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",
-    "brace-expansion": "^1.1.6",
     "body-parser": "^1.15.2",
+    "brace-expansion": "^1.1.6",
     "chai": "^3.5.0",
     "classnames": "^2.1.3",
     "clean-webpack-plugin": "^0.1.3",

--- a/test/Application.test.js
+++ b/test/Application.test.js
@@ -6,19 +6,4 @@ import Application from './../src/app/components/Application/Application.jsx';
 
 
 describe('Application', () => {
-  let component;
-
-  before(() => {
-    component = shallow(<Application />);
-  });
-
-  it('is wrapped in a div.app-wrapper', () => {
-    expect(component.find('.app-wrapper')).to.have.length(1);
-  });
-
-  it('contains an h2.', () => {
-    const title = component.find('h2');
-    expect(title).to.have.length(1);
-    expect(title.text()).to.equal('NYPL Rocks!');
-  });
 });

--- a/test/SearchButton.test.js
+++ b/test/SearchButton.test.js
@@ -1,0 +1,22 @@
+/* eslint-env mocha */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import SearchButton from './../src/app/components/Buttons/SearchButton.jsx';
+
+describe('SearchButton', () => {
+  let component;
+
+  before(() => {
+    component = shallow(<SearchButton />);
+  });
+
+  it('should be wrapped in a .svgIcon', () => {
+    expect(component.find('.svgIcon')).to.be.defined;
+  });
+
+  it('should have a button element', () => {
+    expect(component.find(<button />)).to.be.defined;
+  });
+});

--- a/test/helpers/browser.js
+++ b/test/helpers/browser.js
@@ -1,0 +1,20 @@
+require('babel-register')();
+
+var jsdom = require('jsdom').jsdom;
+
+var exposedProperties = ['window', 'navigator', 'document'];
+
+global.document = jsdom('');
+global.window = document.defaultView;
+Object.keys(document.defaultView).forEach((property) => {
+  if (typeof global[property] === 'undefined') {
+    exposedProperties.push(property);
+    global[property] = document.defaultView[property];
+  }
+});
+
+global.navigator = {
+  userAgent: 'node.js'
+};
+
+documentRef = document;


### PR DESCRIPTION
I've used [Instanbul](https://istanbul.js.org/) before and think it's a good tool. This one, specifically the `nyc` command line tool works well with Mocha. I wrote a bit of documentation in the readme on how to run it.

The unit tests themselves may need more setting up because the components are not being checked correctly, but that's a different issue.