### PR TITLE
Updating external links for OCLC. Updating the LCC display and search link.

### DIFF
--- a/src/app/components/ItemPage/ItemPage.jsx
+++ b/src/app/components/ItemPage/ItemPage.jsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { Link } from 'react-router';
 import {
   findWhere as _findWhere,
-  findIndex as _findIndex
+  findIndex as _findIndex,
 } from 'underscore';
 
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs.jsx';
@@ -28,11 +28,11 @@ class ItemPage extends React.Component {
         const value = q[1].replace('"', '');
 
         // Find the index where the field exists in the list of facets from the API
-        let index = _findIndex(response.data.facets.itemListElement, { field });
+        const index = _findIndex(response.data.facets.itemListElement, { field });
 
         // If the index exists, try to find the facet value from the API
         if (response.data.facets.itemListElement[index]) {
-          let facet = _findWhere(response.data.facets.itemListElement[index].values, { value });
+          const facet = _findWhere(response.data.facets.itemListElement[index].values, { value });
 
           // The API may return a list of facets in the selected field, but the wanted
           // facet may still not appear. If that's the case, return the clicked facet value.
@@ -49,8 +49,8 @@ class ItemPage extends React.Component {
             [field]: {
               id: value,
               value,
-            }
-          })
+            },
+          });
         }
         Actions.updateSearchResults(response.data.searchResults);
         Actions.updateFacets(response.data.facets);
@@ -61,6 +61,42 @@ class ItemPage extends React.Component {
       .catch(error => {
         console.log(error);
       });
+  }
+
+  getDisplayFields(record, data) {
+    if (!data.length) return [];
+
+    let displayFields = [];
+    data.forEach((f) => {
+      // skip absent fields
+      if (!record[f.field] || !record[f.field].length) return false;
+      const fieldValue = record[f.field][0];
+
+      // external links
+      if (f.url) {
+        displayFields.push({
+          term: f.label,
+          definition: <ul>{record[f.field].map((value, i) => {
+            const v = f.field === 'idOwi' ? value.substring(8) : value;
+            return <li key={i}><a target="_blank" href={f.url(v)}>{v}</a></li>
+          })}</ul>,
+        });
+
+      // list of links
+      } else if (fieldValue['@id']) {
+        displayFields.push({ term: f.label, definition: <ul>{record[f.field].map((obj, i) => (<li key={i}><a onClick={(e) => this.onClick(e, `${f.field}:"${obj['@id']}"`)} href={`/search?q=${encodeURIComponent(`${f.field}:"${obj['@id']}"`)}`}>{obj.prefLabel}</a></li>))}</ul> });
+
+      // list of links
+      } else if (f.linkable) {
+        displayFields.push({ term: f.label, definition: <ul>{record[f.field].map((value, i) => (<li key={i}><a onClick={(e) => this.onClick(e, `${f.field}:"${value}"`)} href={`/search?q=${encodeURIComponent(`${f.field}:"${value}"`)}`}>{value}</a></li>))}</ul> });
+
+      // list of plain text
+      } else {
+        displayFields.push({ term: f.label, definition: <ul>{record[f.field].map((value, i) => (<li key={i}>{value}</li>))}</ul> });
+      }
+    });
+
+    return displayFields;
   }
 
   render() {
@@ -90,73 +126,31 @@ class ItemPage extends React.Component {
     const hathiEmbedURL = record.hathiVols && record.hathiVols.length ? `//hdl.handle.net/2027/${record.hathiVols[0].volumeId}?urlappend=%3Bui=embed` : '';
     const hathiURL = record.hathiVols && record.hathiVols.length ? `https://hdl.handle.net/2027/${record.hathiVols[0].volumeId}` : '';
 
-    // const externalData = [
-    //   // { term: 'Publisher\'s summary', definition: `<ul>
-    //   //     <li>This authoritative edition of the complete texts of the "Federalist Papers", the Articles of Confederation, the U.S. Constitution, and the Amendments to the U.S. Constitution features supporting essays in which leading scholars provide historical context and analysis. An introduction by Ian Shapiro offers an overview of the publication of the "Federalist Papers" and their importance. In three additional essays, John Dunn explores the composition of the "Federalist Papers" and the conflicting agendas of its authors; Eileen Hunt Botting explains how early advocates of women's rights, most prominently Mercy Otis Warren, Judith Sargent Murray, and Charles Brockden Brown, responded to the Federalist-Antifederalist debates; and Donald Horowitz discusses the "Federalist Papers" from the perspective of recent experiments with democracy and constitution-making around the world. These essays both illuminate the original texts and encourage active engagement with them.</li>
-    //   //     <li>Source: <a href="#">Nielsen Book Data</a></li>
-    //   //   </ul>`
-    //   // },
-    //   // { term: 'Wikipedia summary', definition: `<ul>
-    //   //     <li>The Federalist is a collection of 85 articles and essays written by Alexander Hamilton, James Madison, and John Jay promoting the ratification of the United States Constitution.</li>
-    //   //     <li>Source: <a href="https://en.wikipedia.org/wiki/The_Federalist_Papers">Wikipedia</a></li>
-    //   //   </ul>`
-    //   // },
-    // ];
-    // const externalLinks = [
-    //   // { term: '<a href="http://billi.nypl.org/">NYPL B.I.L.L.I.</a>', definition: '<a href="http://billi.nypl.org/classmark/KF4501-4515">KF4501-4515</a>' },
-    //   // { term: '<a href="http://worldcat.org/">Worldcat</a>', definition: '<a href="http://worldcat.org/oclc/262432319">262432319</a>' },
-    //   // { term: '<a href="http://worldcat.org/">Worldcat</a>', definition: '<a href="http://worldcat.org/oclc/305151457">305151457</a>' },
-    //   // { term: '<a href="http://classify.oclc.org/">OCLC Classification</a>', definition: '<a href="http://classify.oclc.org/classify2/ClassifyDemo?owi=1090692939">1090692939</a>' },
-    // ];
-
+    const externalFields = [
+      { label: 'OCLC Number', field: 'idOclc', url: (id) => `http://worldcat.org/oclc/${id}` },
+      { label: 'OCLC Workid', field: 'idOwi', url: (id) => `http://classify.oclc.org/classify2/ClassifyDemo?owi=${id}` },
+    ];
     const displayFields = [
-      {label: 'Title', field: 'title'},
-      {label: 'Type', field: 'type'},
-      {label: 'Language', field: 'language'},
-      {label: 'Date Created', field: 'createdYear'},
-      {label: 'Date Published', field: 'startYear'},
-      {label: 'Contributors', field: 'contributor', linkable: true},
-      {label: 'Publisher', field: 'publisher', linkable: true},
-      {label: 'Place of publication', field: 'placeOfPublication'},
-      {label: 'Subjects', field: 'subject'},
-      {label: 'Dimensions', field: 'dimensions'},
-      {label: 'Issuance', field: 'issuance'},
-      {label: 'Owner', field: 'owner'},
-      {label: 'Location', field: 'location'},
-      {label: 'Notes', field: 'note'},
-      {label: 'Bnumber', field: 'idBnum'},
-      {label: 'LCCN', field: 'idLcc'},
-      {label: 'OCLC Number', field: 'idOclc', url: 'http://worldcat.org/oclc/{id}'},
-      {label: 'OCLC Workid', field: 'idOwi', url: 'http://classify.oclc.org/classify2/ClassifyDemo?owi={id}'}
-    ]
+      { label: 'Title', field: 'title' },
+      { label: 'Type', field: 'type' },
+      { label: 'Language', field: 'language' },
+      { label: 'Date Created', field: 'createdYear' },
+      { label: 'Date Published', field: 'startYear' },
+      { label: 'Contributors', field: 'contributor', linkable: true },
+      { label: 'Publisher', field: 'publisher', linkable: true },
+      { label: 'Place of publication', field: 'placeOfPublication' },
+      { label: 'Subjects', field: 'subject' },
+      { label: 'Dimensions', field: 'dimensions' },
+      { label: 'Issuance', field: 'issuance' },
+      { label: 'Owner', field: 'owner' },
+      { label: 'Location', field: 'location' },
+      { label: 'Notes', field: 'note' },
+      { label: 'Bnumber', field: 'idBnum' },
+      { label: 'LCC', field: 'idLcc', linkable: true },
+    ];
 
-    let itemDetails = [];
-    displayFields.forEach((f) => {
-      // skip absent fields
-      if (!record[f.field] || !record[f.field].length) return false;
-      let fieldValue = record[f.field][0];
-
-      // list of links
-      if (fieldValue['@id']) {
-        itemDetails.push({ term: f.label, definition: <ul>{record[f.field].map((obj, i) => (<li key={i}><a onClick={(e) => this.onClick(e, `${f.field}:"${obj['@id']}"`)} href={`/search?q=${encodeURIComponent(`${f.field}:"${obj['@id']}"`)}`}>{obj.prefLabel}</a></li>))}</ul> });
-
-      // list of links
-      } else if (f.linkable) {
-        itemDetails.push({ term: f.label, definition: <ul>{record[f.field].map((value, i) => (<li key={i}><a onClick={(e) => this.onClick(e, `${f.field}:"${value}"`)} href={`/search?q=${encodeURIComponent(`${f.field}:"${value}"`)}`}>{value}</a></li>))}</ul> });
-
-      // list of plain text
-      } else {
-        itemDetails.push({ term: f.label, definition: <ul>{record[f.field].map((value, i) => (<li key={i}>{value}</li>))}</ul> });
-      }
-    });
-
-    // const citeData = [
-    //   // { term: 'APA', definition: 'Hamilton, A., Madison, J., Jay, J., &amp; Shapiro, I. (2009). The Federalist papers: Alexander Hamilton, James Madison, John Jay. New Haven: Yale University Press.' },
-    //   // { term: 'MLA', definition: 'Hamilton, Alexander, James Madison, John Jay, and Ian Shapiro. The Federalist Papers: Alexander Hamilton, James Madison, John Jay. New Haven: Yale University Press, 2009. Print.' },
-    //   // { term: 'CHICAGO', definition: 'Hamilton, Alexander, James Madison, John Jay, and Ian Shapiro. 2009. The Federalist papers: Alexander Hamilton, James Madison, John Jay. New Haven: Yale University Press.' },
-    //   // { term: 'HARVARD', definition: 'HAMILTON, A., MADISON, J., JAY, J., &amp; SHAPIRO, I. (2009). The Federalist papers: Alexander Hamilton, James Madison, John Jay. New Haven, Yale University Press.' },
-    //   // { term: 'TURABIAN', definition: 'Hamilton, Alexander, James Madison, John Jay, and Ian Shapiro. The Federalist Papers: Alexander Hamilton, James Madison, John Jay. New Haven: Yale University Press, 2009.' },
-    // ];
+    let externalLinks = this.getDisplayFields(record, externalFields);
+    let itemDetails = this.getDisplayFields(record, displayFields);
 
     return (
       <div id="mainContent">
@@ -213,14 +207,16 @@ class ItemPage extends React.Component {
               title="Item details"
             />
 
-            {/*
+            <ItemDetails
+              data={externalLinks}
+              title="External links"
+            />
 
+            {/*
             <ItemDetails data={externalData} title="External data" />
 
-            <ItemDetails data={externalLinks} title="External links" />
-
             <ItemDetails data={citeData} title="Cite this book" />
-          */}
+            */}
           </div>
 
           <ItemEditions title={title} item={record} />

--- a/src/app/components/ItemPage/ItemPage.jsx
+++ b/src/app/components/ItemPage/ItemPage.jsx
@@ -146,7 +146,7 @@ class ItemPage extends React.Component {
       { label: 'Location', field: 'location' },
       { label: 'Notes', field: 'note' },
       { label: 'Bnumber', field: 'idBnum' },
-      { label: 'LCC', field: 'idLcc', linkable: true },
+      { label: 'LCC', field: 'idLcc' },
     ];
 
     let externalLinks = this.getDisplayFields(record, externalFields);


### PR DESCRIPTION
This PR is for issues #86 and #85.

I added the OCLC number and workid under "External Links", for now. It doesn't seem like all links to OCLC work such as the link on this page: http://dev-discovery.nypl.org/item/b18534869.

For issue #85, the LCC label is updated but the API doesn't support it right now so it's not linked.