### PR TITLE
Updated header login

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "nyc": "^9.0.1"
   },
   "dependencies": {
-    "@nypl/dgx-header-component": "git+https://git@bitbucket.org/NYPL/dgx-header-component#update-log-out-link",
+    "@nypl/dgx-header-component": "git+https://git@bitbucket.org/NYPL/dgx-header-component#alpha-oauth-login-with-feature-flag",
     "@nypl/dgx-react-footer": "0.3.0",
     "alt": "^0.18.2",
     "axios": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "nyc": "^9.0.1"
   },
   "dependencies": {
-    "@nypl/dgx-header-component": "git+https://git@bitbucket.org/NYPL/dgx-header-component#alpha-oauth-login-with-feature-flag",
+    "@nypl/dgx-header-component": "git+https://git@bitbucket.org/NYPL/dgx-header-component#updated-urls-for-user-test",
     "@nypl/dgx-react-footer": "0.3.0",
     "alt": "^0.18.2",
     "axios": "^0.9.1",

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -55,8 +55,15 @@ button {
   }
 }
 
+// Overrides for other components
 .footer {
   a {
     background-color: #54514A;
+  }
+}
+
+.MyNypl-Login-List {
+  li {
+    margin-bottom: 0;
   }
 }


### PR DESCRIPTION
I talked to kang about the alpha branches in the Header that have the logged in feature. The most current alpha branch logs you in but it shows the same logged in form without any indication that it was successful, or a redirect to the current page.

This PR has an alternate branch that logs you in and takes you to the "My Account" page in nypl-sierra-test. Besides this, the navigation links take you to a dev instance of nypl.org since it was meant to be used for user testing.

Not sure if it's going to be a problem if you try to log in through the header. If you are not logged in and you log in when placing a hold, the redirect will work and that user flow is unaffected.

Last thing, the links to the oauth endpoints are now behind a "feature flag" that triggers it. So in order to log in the catalogs through the header, you have to either:

1. type `dgxFeatureFlags.activateFeature('OauthLogin');` into the console, or
2. set an NYPL wide cookie that will trigger the oath endpoints at http://dev-octane.nypl.org/connect/login-user-test.

This is currently up on dev-discovery.nypl.org
