### PR TITLE
Removing overflow hidden CSS rule from focus state.

### DIFF
--- a/src/app/components/FacetSidebar/FacetSidebar.jsx
+++ b/src/app/components/FacetSidebar/FacetSidebar.jsx
@@ -185,7 +185,7 @@ class FacetSidebar extends React.Component {
           {
             this.props.keywords ?
             <fieldset>
-              <legend className="facet-legend">Remove {this.props.keyword} keyword</legend>
+              <legend className="facet-legend visuallyHidden">Remove {this.props.keyword} keyword</legend>
               <label htmlFor="select-keywords">Keywords</label>
               <button
                 id="select-keywords"
@@ -203,8 +203,6 @@ class FacetSidebar extends React.Component {
 
           {facetsElm}
 
-          <button className="visuallyHidden" type="submit">Search</button>
-          
         </form>
       </div>
     );

--- a/src/client/styles/utils/utils.scss
+++ b/src/client/styles/utils/utils.scss
@@ -6,11 +6,6 @@
   @include displayVisuallyHidden;
 }
 
-// For FireFox
-:focus {
-  overflow: hidden;
-}
-
 $app-max-width: 1313px !default;
 $tablet-portrait: 768px !default;
 $tablet-landscape: 1024px !default;


### PR DESCRIPTION
The CSS rule messes up the select element on Firefox. I added it before but forgot why... I tested FF again and don't see anything apparent that messes up after removing the rule.

Also removed the visually hidden submit button for now. That causes the form to submit when an option is chosen. I think the larger discussion can be whether it should always make a fetch to the server and refresh the page, or continue with the ajax update.