### PR TITLE
More descriptive labels for calls-to-action for screen readers

### DIFF
--- a/src/app/components/Results/ResultsList.jsx
+++ b/src/app/components/Results/ResultsList.jsx
@@ -53,6 +53,7 @@ class ResultsList extends React.Component {
     const moreCount = itemCount - maxDisplay;
     const expandedItems = this.state.expandedItems;
     const resultId = result.idBnum;
+    const resultTitle = result.title[0];
 
     return items.map((item, i) => {
       const status = item.status;
@@ -82,6 +83,7 @@ class ResultsList extends React.Component {
                   href={item.url}
                   className="button">
                   {item.actionLabel}
+                  <span className="visuallyHidden"> {item.actionLabelHelper}</span>
                 </a>
               : null}
             </div>
@@ -94,6 +96,7 @@ class ResultsList extends React.Component {
                   href="#"
                   className="see-more-link">
                   See {moreCount} more item{moreCount > 1 ? 's' : ''}
+                  <span className="visuallyHidden"> in collapsed menu for {resultTitle}</span>
                 </Link>
               )
               : null

--- a/src/app/components/SearchResultsPage/SearchResultsPage.jsx
+++ b/src/app/components/SearchResultsPage/SearchResultsPage.jsx
@@ -48,11 +48,12 @@ class SearchResultsPage extends React.Component {
 
     return (
       <div id="mainContent">
+
+        {breadcrumbs}
+
         <div className="search-container">
           <Search sortBy={sortBy} />
         </div>
-
-        {breadcrumbs}
 
         <div className="container search-results-container">
 

--- a/src/app/utils/item.js
+++ b/src/app/utils/item.js
@@ -32,6 +32,7 @@ function LibraryItem() {
    * @param (Object) record
    */
   this.getItems = (record) => {
+    const recordTitle = record.title[0];
     // filter out anything without a status or location
     let items = record.items.filter((item, i) => {
       return (item.location && item.status) || item.electronicLocator;
@@ -45,6 +46,7 @@ function LibraryItem() {
       const location = this.getLocationLabel(item);
       let url = null;
       let actionLabel = null;
+      let actionLabelHelper = null;
       const isElectronicResource = this.isElectronicResource(item);
 
       if (isElectronicResource && item.electronicLocator[0].url) {
@@ -52,10 +54,12 @@ function LibraryItem() {
         availability = 'available';
         url = item.electronicLocator[0].url;
         actionLabel = 'View online';
+        actionLabelHelper = `resource for ${recordTitle}`;
 
       } else if (availability === 'available') {
         url = `/hold/request/${id}`;
         actionLabel = 'Request a hold';
+        actionLabelHelper = `for ${recordTitle} for use in library`;
       }
 
       return {
@@ -67,7 +71,8 @@ function LibraryItem() {
         location: location,
         callNumber: callNumber,
         url: url,
-        actionLabel: actionLabel
+        actionLabel: actionLabel,
+        actionLabelHelper: actionLabelHelper
       }
     });
 


### PR DESCRIPTION
- For "Request a hold" button, added "Request a hold for [title] for use in library"
- For "View online" button, added "View online resource for [title]"  (this could still use more work)
- For "See XX more items" link, added "See XX more items in collapsed menu for [title] (#114)

(Sorry, I also snuck in #106 because it was trivial change)