### PR TITLE
Adding tabIndex to fieldset so voice over reads the legend.

### DIFF
--- a/src/app/components/FacetSidebar/FacetSidebar.jsx
+++ b/src/app/components/FacetSidebar/FacetSidebar.jsx
@@ -140,15 +140,11 @@ class FacetSidebar extends React.Component {
         if (facet.values.length < 1 || field === 'carrierType' || field === 'mediaType') {
           return null;
         }
-        // if (field === 'dates') {
-        //   dateRange = facet;
-        //   return null;
-        // }
 
         const selectedValue = this.state[field] ? this.state[field].id : '';
 
         return (
-          <fieldset key={i}>
+          <fieldset key={i} tabIndex="0">
             <legend className="facet-legend visuallyHidden">Filter by {facet.field}</legend>
             <label htmlFor={`select-${field}`}>{facet.field}</label>
             <select
@@ -184,8 +180,8 @@ class FacetSidebar extends React.Component {
           <h2>Filter results by</h2>
           {
             this.props.keywords ?
-            <fieldset>
-              <legend className="facet-legend visuallyHidden">Remove {this.props.keyword} keyword</legend>
+            <fieldset tabIndex="0">
+              <legend className="facet-legend visuallyHidden">Current Keyword {this.props.keyword}</legend>
               <label htmlFor="select-keywords">Keywords</label>
               <button
                 id="select-keywords"


### PR DESCRIPTION
This is for #107 .
Tested with VoiceOver but FireFox doesn't seem to read them and I can't figure out the FF settings.

I'm following these keyboard navigation interactions from webaim: http://webaim.org/techniques/keyboard/

This PR also ties in with #108. It seems that the `spacebar` is the correct key to expand a dropdown instead of enter (enter would be to select an option). But, FF doesn't follow this rule. Neither `space` or `enter` expands a dropdown menu in FF. The tested this functionality on this page, also from webaim, http://webaim.org/techniques/forms/controls. The dropdown select menus don't open up in FF, but you can select with the up and down arrows. That's the same interaction in the facets dropdown.

I think it's a good start and set of rules to follow but user testing will further help.