### PR TITLE
Updating pagination links to be keyboard and voice over accessible.

### DIFF
--- a/src/app/components/Results/Results.jsx
+++ b/src/app/components/Results/Results.jsx
@@ -42,8 +42,13 @@ class Results extends React.Component {
     const pageNum = type === 'next' ?  parseInt(page, 10) + 1 : parseInt(page, 10) - 1;
 
     return (
-      <a className={`paginate ${type}`} onClick={(e) => this.fetchResults(pageNum)}>
-        {type[0].toUpperCase()}{type.substring(1)} Page
+      <a
+        href="#"
+        className={`paginate ${type}`}
+        onClick={(e) => this.fetchResults(pageNum)}
+        rel={type}
+      >
+        {`${type[0].toUpperCase()}${type.substring(1)}`} Page
       </a>
     );
   }
@@ -98,7 +103,13 @@ class Results extends React.Component {
     const paginationButtons = (
       <div className="pagination">
         {prevPage}
-        <span className="paginate pagination-total">{displayItems} of {hitsF}</span>
+        <span
+          className="paginate pagination-total"
+          aria-label={`Displaying ${displayItems} out of ${hitsF} total items.`}
+          tabIndex="0"
+        >
+          {displayItems} of {hitsF}
+        </span>
         {nextPage}
       </div>
     );


### PR DESCRIPTION
Also added `rel="prev"` and `rel="next"` to the previous and next links as per [recommendation](https://webmasters.googleblog.com/2011/09/pagination-with-relnext-and-relprev.html).

I'm just not sure if adding the `tabIndex` and `aria-label` attributes to the span to read the number of items displayed is the best approach.