### PR TITLE
Adding React specific a11y packages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "airbnb"  
+  "extends": [
+    "airbnb",
+    "plugin:jsx-a11y/recommended"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -59,6 +59,30 @@ To run the code coverage tool and view a better report, run
 
 This last command will create a folder called `coverage` in the root directory. You can open up `coverage/lcov-report/index.html` in a browser to see more details about what lines of codes have not been tested.
 
+## React Accessibility
+
+### eslint-plugin-jsx-a11y
+Adding accessibility rule checker through ESLint and the [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y) plugin. This checks accessibility issues when ESLint is ran in the command line.
+
+Note: At the moment, use ESLint as the global package by install the packages:
+
+    $ sudo npm install -g eslint eslint-plugin-jsx-a11y eslint-config-airbnb
+
+And to check files run:
+
+    $ eslint src/app/components/.../path/to/file.jsx
+
+Or all components at once:
+
+    $ eslint src/app/components/**/*
+
+### react-a11y
+[react-a11y](https://github.com/reactjs/react-a11y) is an npm package that can be run in development mode when the `loadA11y` environment variable is set to true.
+
+    $ loadA11y=true npm start
+
+This will output warnings in the browser's console for elements that do not meet accessibility standards. Some rules may be too strict and should be verified against other accessibility rules.
+
 ## Misc
 
 Starting up from a [Node/React boilerplate](https://bitbucket.org/NYPL/dgx-nypl-react-boilerplate).

--- a/package.json
+++ b/package.json
@@ -48,7 +48,10 @@
   },
   "devDependencies": {
     "axios-mock-adapter": "^1.7.1",
-    "nyc": "^9.0.1"
+    "eslint-config-airbnb": "^13.0.0",
+    "eslint-plugin-jsx-a11y": "^3.0.1",
+    "nyc": "^9.0.1",
+    "react-a11y": "^0.3.3"
   },
   "dependencies": {
     "@nypl/dgx-header-component": "git+https://git@bitbucket.org/NYPL/dgx-header-component#updated-urls-for-user-test",

--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -1,10 +1,13 @@
+/* global loadA11y */
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router, useRouterHistory } from 'react-router';
 import createBrowserHistory from 'history/lib/createBrowserHistory';
 import useScroll from 'scroll-behavior/lib/useStandardScroll';
 import FeatureFlags from 'dgx-feature-flags';
-import { ga } from 'dgx-react-ga';
+// import { ga } from 'dgx-react-ga';
+import a11y from 'react-a11y';
 
 import alt from '../app/alt.js';
 import Iso from 'iso';
@@ -12,6 +15,10 @@ import Iso from 'iso';
 import './styles/main.scss';
 
 import routes from '../app/routes/routes.jsx';
+
+if (loadA11y) {
+  a11y(React, { ReactDOM, includeSrcNode: true });
+}
 
 window.onload = () => {
   // Used to activate/deactivate AB tests on global namespace.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,9 @@ const commonSettings = {
     // part of the package.json scripts.
     new cleanBuild(['dist']),
     new ExtractTextPlugin('styles.css'),
+    new webpack.DefinePlugin({
+      loadA11y: process.env.loadA11y || false,
+    }),
   ],
 };
 


### PR DESCRIPTION
Adding react-a11y to check react component accessibility at run time and eslint-plugin-jsx-a11y to catch accessibility issues when running code through eslint.